### PR TITLE
Update serializers to return only id for relations

### DIFF
--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -10,9 +10,16 @@ class DiscussionSerializer < ActiveModel::Serializer
              :current_user_session_votes,
              :current_user_total_votes,
              :can_downvote,
-             :admin?
-  has_one :discussion_proposer
-  has_many :users, through: :votes
+             :admin?,
+             :user_id
+
+  has_many :users, through: :votes do
+    object.users.pluck(:id)
+  end
+
+  has_many :votes do
+    object.votes.pluck(:id)
+  end
 
   def editable
     scope == object.discussion_proposer

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -7,10 +7,12 @@ class EventSerializer < ActiveModel::Serializer
              :proposals_open,
              :voting_open,
              :schedule_finalized,
-             :user,
-             :stage
+             :stage,
+             :user_id
 
-  has_many :timeslots
+  has_many :timeslots do
+    object.timeslots.pluck(:id)
+  end
 
   def stage
     if object.proposals_open && !object.voting_open && !object.schedule_finalized

--- a/app/serializers/timeslot_serializer.rb
+++ b/app/serializers/timeslot_serializer.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class TimeslotSerializer < ActiveModel::Serializer
-  attributes :id, :start_time, :end_time, :room_name
-  has_one :event
-  has_one :user
+  attributes :id,
+             :start_time,
+             :end_time,
+             :room_name,
+             :event_id,
+             :user_id
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :admin
-  has_many :discussions_proposed
-  has_many :discussions, through: :votes
-  has_many :events
-  has_many :timeslots
+  attributes :id,
+             :email,
+             :admin
+
+  has_many :discussions_proposed do
+    object.discussions_proposed.pluck(:id)
+  end
+  has_many :discussions, through: :votes do
+    object.discussions.pluck(:id)
+  end
+  has_many :events do
+    object.events.pluck(:id)
+  end
+
+  has_many :timeslots do
+    object.timeslots.pluck(:id)
+  end
 end

--- a/app/serializers/vote_serializer.rb
+++ b/app/serializers/vote_serializer.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class VoteSerializer < ActiveModel::Serializer
-  attributes :id
-  has_one :user
-  has_one :discussion
-
+  attributes :id,
+             :user_id,
+             :discussion_id
 end


### PR DESCRIPTION
- Update serializers to return only the IDs of has_many relations using
'pluck'